### PR TITLE
Feat: 계산화면 화폐 단위 등, 유저디폴트와 동기화

### DIFF
--- a/TaxRefundCalculator/CalculatePage/CalculateVC.swift
+++ b/TaxRefundCalculator/CalculatePage/CalculateVC.swift
@@ -11,8 +11,8 @@ import Then
 
 class CalculateVC: UIViewController {
     
-    let viewModel = CalculateVM()
-    
+    private let viewModel = CalculateVM()
+
     // MARK: 사이즈 대응을 위한 스크롤 뷰
     let scrollView = UIScrollView()
     let scrollContentView = UIView()
@@ -31,10 +31,33 @@ class CalculateVC: UIViewController {
         $0.font = UIFont.systemFont(ofSize: 19, weight: .bold)
         $0.textColor = .primaryText
     }
-    private let rate = UILabel().then {
-        $0.text = "1 EUR   =   1,430 KRW"
+    private let currency1Num = UILabel().then {
+        $0.text = "1"
         $0.font = UIFont.systemFont(ofSize: 17, weight: .regular)
         $0.textColor = .subText
+    }
+    private let currency1 = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: 17, weight: .regular)
+        $0.textColor = .subText
+    }
+    private let equal = UILabel().then {
+        $0.text = " = "
+        $0.font = UIFont.systemFont(ofSize: 17, weight: .regular)
+        $0.textColor = .subText
+    }
+    private let currency2Num = UILabel().then {
+        $0.text = "999"
+        $0.font = UIFont.systemFont(ofSize: 17, weight: .regular)
+        $0.textColor = .subText
+    }
+    private let currency2 = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: 17, weight: .regular)
+        $0.textColor = .subText
+    }
+    private lazy var currencyStackView = UIStackView(arrangedSubviews: [currency1Num, currency1, equal, currency2Num, currency2]).then {
+        $0.axis = .horizontal
+        $0.spacing = 5
+        $0.distribution = .fillProportionally
     }
     
     
@@ -49,10 +72,9 @@ class CalculateVC: UIViewController {
     }
     private let priceLabel = UILabel().then {
         $0.text = "구매 금액 입력"
-        $0.font = UIFont.systemFont(ofSize: 15, weight: .regular)
+        $0.font = UIFont.systemFont(ofSize: 19, weight: .regular)
     }
     private let textFieldLabel = UILabel().then {
-        $0.text = "EUR    "
         $0.textColor = .subText
         $0.font = UIFont.systemFont(ofSize: 14, weight: .bold)
     }
@@ -67,7 +89,12 @@ class CalculateVC: UIViewController {
         $0.rightView = textFieldLabel
         $0.rightViewMode = .always
     }
-    
+    private let calculateBtn = UIButton().then {
+        $0.backgroundColor = .mainTeal
+        $0.setTitle("계산하기", for: .normal)
+        $0.layer.cornerRadius = 8
+        $0.addTarget(self, action: #selector(calculateBtnTapped), for: .touchUpInside)
+    }
     
     // MARK: 계산 카드
     private let calculateCard = UIView().then {
@@ -93,13 +120,25 @@ class CalculateVC: UIViewController {
         $0.text = "예상 환급 금액"
         $0.font = UIFont.systemFont(ofSize: 17, weight: .regular)
     }
-    private let result = UILabel().then {
-        $0.text = "0.00 EUR"
+    private let resultNum = UILabel().then {
+        $0.text = "10.00"
         $0.font = UIFont.systemFont(ofSize: 30, weight: .bold)
         $0.textColor = .mainTeal
     }
-    private let summary = UILabel().then {
+    private let resultCurrency = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: 30, weight: .bold)
+        $0.textColor = .mainTeal
+    }
+    private lazy var resultStackView = UIStackView(arrangedSubviews: [resultNum, resultCurrency]).then {
+        $0.axis = .horizontal
+        $0.spacing = 5
+        $0.distribution = .fill
+    }
+    private let summaryNum = UILabel().then {
         $0.text = "약 0 KRW"
+        $0.font = UIFont.systemFont(ofSize: 16.5, weight: .thin)
+    }
+    private let summaryCurrency = UILabel().then {
         $0.font = UIFont.systemFont(ofSize: 16.5, weight: .thin)
     }
     private lazy var saveBtn = UIButton().then {
@@ -124,15 +163,35 @@ class CalculateVC: UIViewController {
         super.viewDidLoad()
         
         configureUI()
-        loadTravelCurrency()
+        loadFromUserdefaults()
     }
     
     
     // MARK: UserDefaults에서 값 불러오기
-    private func loadTravelCurrency() {
+    private func loadFromUserdefaults() {
+        // 여행국가화폐 불러오기
         if let savedTravelCurrency = viewModel.getTravelCurrency() {
-            travelCurrency.text = savedTravelCurrency
+            travelCurrency.text = savedTravelCurrency // 최상단 선택된 여행국가 Label
+            
+            let travelCurrencyLast3 = String(savedTravelCurrency.suffix(3)) // 뒤에서 3글자. 화폐단위만 추출
+            
+            currency1.text = " \(travelCurrencyLast3)" // 현재 환율 칸
+            textFieldLabel.text = "\(travelCurrencyLast3)    " // 구매금액 입력칸
+            resultCurrency.text = " \(travelCurrencyLast3)" // 예상환급금액 칸
         }
+        
+        // 기준화폐 가져오기
+        if let savedBaseCurrency = viewModel.getBaseCurrency() {
+            let baseCurrencyLast3 = String(savedBaseCurrency.suffix(3)) // 뒤에서 3글자. 화폐단위만 추출
+            
+            currency2.text = " \(baseCurrencyLast3)" // 현재 환욜 칸
+        }
+        
+        // 부가세율 가져오기
+        if let (flag, policy) = viewModel.getRefundPolicyByCurrency() {
+            percent.text = "\(policy.vatRate)%"
+        }
+
     }
     
     
@@ -163,14 +222,14 @@ class CalculateVC: UIViewController {
         }
         
         currencyRateCard.addSubview(travelCurrency)
-        currencyRateCard.addSubview(rate)
+        currencyRateCard.addSubview(currencyStackView)
         
         travelCurrency.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(16)
             $0.top.equalToSuperview().offset(16)
         }
-        rate.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(16)
+        currencyStackView.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(16)
             $0.bottom.equalToSuperview().inset(16)
         }
         
@@ -180,20 +239,28 @@ class CalculateVC: UIViewController {
         priceCard.snp.makeConstraints {
             $0.top.equalTo(currencyRateCard.snp.bottom).offset(16)
             $0.leading.trailing.equalToSuperview().inset(16)
-            $0.height.equalTo(120)
+            $0.height.equalTo(180)
         }
         
         priceCard.addSubview(priceLabel)
         priceCard.addSubview(priceTextField)
+        priceCard.addSubview(calculateBtn)
         
         priceLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(20)
+            $0.top.equalToSuperview().offset(16)
             $0.leading.trailing.equalToSuperview().inset(16)
+            
         }
         priceTextField.snp.makeConstraints {
-            $0.bottom.equalToSuperview().inset(20)
+            $0.top.equalTo(priceLabel.snp.bottom).offset(16)
             $0.leading.trailing.equalToSuperview().inset(16)
             $0.height.equalTo(50)
+        }
+        calculateBtn.snp.makeConstraints {
+            $0.top.equalTo(priceTextField.snp.bottom).offset(16)
+            $0.bottom.equalToSuperview().inset(16)
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.height.equalTo(40)
         }
         
         
@@ -210,8 +277,8 @@ class CalculateVC: UIViewController {
         calculateCard.addSubview(percent)
         calculateCard.addSubview(separator)
         calculateCard.addSubview(expectation)
-        calculateCard.addSubview(result)
-        calculateCard.addSubview(summary)
+        calculateCard.addSubview(resultStackView)
+        calculateCard.addSubview(summaryNum)
         calculateCard.addSubview(btnStackView)
         
         vatLabel.snp.makeConstraints {
@@ -222,10 +289,6 @@ class CalculateVC: UIViewController {
             $0.top.equalToSuperview().inset(20)
             $0.trailing.equalToSuperview().inset(20)
         }
-        result.snp.makeConstraints {
-            $0.centerX.centerY.equalToSuperview()
-            $0.leading.trailing.equalToSuperview().inset(20)
-        }
         separator.snp.makeConstraints  {
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.top.equalTo(vatLabel.snp.bottom).offset(12)
@@ -233,10 +296,14 @@ class CalculateVC: UIViewController {
         }
         expectation.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(20)
-            $0.bottom.equalTo(result.snp.top).offset(-10)
+            $0.bottom.equalTo(resultCurrency.snp.top).offset(-10)
         }
-        summary.snp.makeConstraints {
-            $0.top.equalTo(result.snp.bottom).offset(5)
+        resultStackView.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().inset(20)
+        }
+        summaryNum.snp.makeConstraints {
+            $0.top.equalTo(resultCurrency.snp.bottom).offset(5)
             $0.leading.equalToSuperview().inset(20)
         }
         btnStackView.snp.makeConstraints {
@@ -252,6 +319,13 @@ class CalculateVC: UIViewController {
     private func checkBtnTapped() {
         let modal = RefundModal()
         present(modal, animated: true, completion: nil)
+    }
+    
+    
+    // MARK: 계산하기 버튼 액션
+    @objc
+    private func calculateBtnTapped() {
+        print("클릭됨")
     }
     
 }

--- a/TaxRefundCalculator/CalculatePage/CalculateVM.swift
+++ b/TaxRefundCalculator/CalculatePage/CalculateVM.swift
@@ -35,18 +35,5 @@ class CalculateVM {
     }
     
     
-    // MARK: 국기 인식 및 환급기준 매칭
-    func getRefundPolicy(for text: String) -> VATRefundPolicy? {
-        // 추출 가능한 이모지 범위로 가정: 국기 이모지 유니코드는 대부분 두 글자
-        let flagEmojis = RefundCondition.flagToPolicyMap.keys
-        
-        for flag in flagEmojis {
-            if text.contains(flag) {
-                return RefundCondition.flagToPolicyMap[flag]
-            }
-        }
-        
-        return nil
-    }
     
 }


### PR DESCRIPTION
## 주요사항
- 계산하기 버튼을 추가했습니다.
추후 이 버튼은 아래 예상 환급금액에 계산 결과를 띄우는 등, 트리거가 될 것입니다.

- 여행국가 통화, 기준 통화 등 유저디폴트에 저장되어 있는 정보를 불러와서 각 위치에 띄우는 작업을 진행하였습니다.
- 저장되어있는 여행국가의 국기를 매칭해서 해당 국가의 환급정책을 불러오고, 거기서 부가세 값을 구해서 띄워주는 작업을 진행하였습니다.

## 스크린샷
<img width="568" alt="스크린샷 2025-06-06 오후 4 30 11" src="https://github.com/user-attachments/assets/76765ec2-dc25-485e-8749-543409059755" />

## 추가계획
- 현재 실시간 환율에서, 기준 통화로 컨버전되어 값이 넘어오는 작업이 진행중인데, 해당 작업이 진행되어야 계산 로직 적용 등의 작업을 거칠 수 있을 것 같습니다.
- 예상 환급 금액, 그 하단에 기준 통화로 변동된 금액 부분은 위에서 언급한 실시간 환율이 기준통화로 컨버전 작업이 마무리 된 후에 일괄적으로 진행 가능할 것 같습니다.