### PR TITLE
Feat: 설정에서 화폐정보 변경시, 계산화면에도 실시간 반영되도록 구현

### DIFF
--- a/TaxRefundCalculator/SettingPage/SettingVC.swift
+++ b/TaxRefundCalculator/SettingPage/SettingVC.swift
@@ -11,7 +11,7 @@ import Then
 
 class SettingVC: UIViewController, LanguageModalDelegate, CountryModalDelegate {
     
-    private let viewModel = SettingVM()
+    private let viewModel = SettingVM.shared // 싱글턴 패턴이기때문에 싱글턴 인스턴스. 새로 생성하면 안됨.
     
     // MARK: 앱 설정 카드
     private let settingCard = UIView().then {
@@ -398,10 +398,10 @@ class SettingVC: UIViewController, LanguageModalDelegate, CountryModalDelegate {
         switch tag {
         case 0:
             nowBaseCurrency.text = country
-            viewModel.saveBaseCurrency(country) // userDefaults에 저장
+            SettingVM.shared.saveBaseCurrency(country) // userDefaults에 저장 및 Combine
         case 1:
             nowCurreny.text = country
-            viewModel.saveTravelCurrency(country) // userDefaults에 저장
+            SettingVM.shared.saveTravelCurrency(country) // userDefaults에 저장 및 Combine
         default:
             break
         }

--- a/TaxRefundCalculator/SettingPage/SettingVC.swift
+++ b/TaxRefundCalculator/SettingPage/SettingVC.swift
@@ -11,6 +11,8 @@ import Then
 
 class SettingVC: UIViewController, LanguageModalDelegate, CountryModalDelegate {
     
+    private let viewModel = SettingVM()
+    
     // MARK: 앱 설정 카드
     private let settingCard = UIView().then {
         $0.backgroundColor = .bgPrimary
@@ -34,7 +36,6 @@ class SettingVC: UIViewController, LanguageModalDelegate, CountryModalDelegate {
         $0.font = .systemFont(ofSize: 17)
     }
     private let nowLanguage = UILabel().then {
-        $0.text = "한국어"
         $0.textColor = .primaryText
         $0.font = .systemFont(ofSize: 17)
     }
@@ -49,7 +50,6 @@ class SettingVC: UIViewController, LanguageModalDelegate, CountryModalDelegate {
         $0.font = .systemFont(ofSize: 17)
     }
     private let nowBaseCurrency = UILabel().then {
-        $0.text = "KRW"
         $0.textColor = .primaryText
         $0.font = .systemFont(ofSize: 17)
     }
@@ -64,7 +64,6 @@ class SettingVC: UIViewController, LanguageModalDelegate, CountryModalDelegate {
         $0.font = .systemFont(ofSize: 17)
     }
     private let nowCurreny = UILabel().then {
-        $0.text = "EUR"
         $0.textColor = .primaryText
         $0.font = .systemFont(ofSize: 17)
     }
@@ -154,6 +153,24 @@ class SettingVC: UIViewController, LanguageModalDelegate, CountryModalDelegate {
         super.viewDidLoad()
         
         configureUI()
+        loadFromUserdefaults()
+    }
+    
+    
+    // MARK: UserDefaults에서 값 불러오기
+    private func loadFromUserdefaults() {
+        // 언어 설정
+        if let loadLanguage = viewModel.getSelectedLanguage() {
+            nowLanguage.text = loadLanguage
+        }
+        // 기준화폐 설정
+        if let loadBaseCurrency = viewModel.getBaseCurrency() {
+            nowBaseCurrency.text = loadBaseCurrency
+        }
+        // 여행화폐 설정
+        if let loadTravelCurrency = viewModel.getTravelCurrency() {
+            nowCurreny.text = loadTravelCurrency
+        }
     }
     
     
@@ -373,14 +390,18 @@ class SettingVC: UIViewController, LanguageModalDelegate, CountryModalDelegate {
     // 언어 선택 부분
     func didSelectLanguage(_ language: String) {
         nowLanguage.text = language
+        viewModel.saveSelectedLanguage(language) // userDefaults에 저장
+        
     }
     // 화폐 선택 부분들
     func didSelectCountry(_ country: String, forFieldTag tag: Int) {
         switch tag {
         case 0:
             nowBaseCurrency.text = country
+            viewModel.saveBaseCurrency(country) // userDefaults에 저장
         case 1:
             nowCurreny.text = country
+            viewModel.saveTravelCurrency(country) // userDefaults에 저장
         default:
             break
         }

--- a/TaxRefundCalculator/SettingPage/SettingVM.swift
+++ b/TaxRefundCalculator/SettingPage/SettingVM.swift
@@ -11,4 +11,30 @@ import Then
 
 class SettingVM {
     
+    let saveUserDefaults = SaveUserDefaults()
+    
+    // MARK: userDefaults 저장 메서드
+    func saveSelectedLanguage(_ language: String) {
+        saveUserDefaults.saveLanguage(language)
+    }
+    func saveBaseCurrency(_ baseCurrency: String) {
+        saveUserDefaults.saveBaseCurrency(baseCurrency)
+    }
+    func saveTravelCurrency(_ travelCurrency: String) {
+        saveUserDefaults.saveTravelCurrency(travelCurrency)
+    }
+    
+    // MARK: userDefaults 조회 메서드
+    func getSelectedLanguage() -> String? {
+        return saveUserDefaults.getLanguage()
+    }
+    func getBaseCurrency() -> String? {
+        return saveUserDefaults.getBaseCurrency()
+    }
+    func getTravelCurrency() -> String? {
+        return saveUserDefaults.getTravelCurrency()
+    }
+    
+    
+    
 }

--- a/TaxRefundCalculator/SettingPage/SettingVM.swift
+++ b/TaxRefundCalculator/SettingPage/SettingVM.swift
@@ -8,8 +8,17 @@
 import Foundation
 import SnapKit
 import Then
+import Combine
 
 class SettingVM {
+    
+    // MARK: 싱글톤 패턴
+    static let shared = SettingVM()
+    private init() {} // 외부에서 생성 방지
+    
+    // MARK: Combine - 기존화폐, 여행화폐 변경시 최신화를 위함
+    @Published var baseCurrency: String = ""
+    @Published var travelCurrency: String = ""
     
     let saveUserDefaults = SaveUserDefaults()
     
@@ -18,10 +27,12 @@ class SettingVM {
         saveUserDefaults.saveLanguage(language)
     }
     func saveBaseCurrency(_ baseCurrency: String) {
-        saveUserDefaults.saveBaseCurrency(baseCurrency)
+        saveUserDefaults.saveBaseCurrency(baseCurrency) // 유저디폴트에 저장
+        self.baseCurrency = baseCurrency // @Published 갱신
     }
     func saveTravelCurrency(_ travelCurrency: String) {
-        saveUserDefaults.saveTravelCurrency(travelCurrency)
+        saveUserDefaults.saveTravelCurrency(travelCurrency) // 유저디폴트에 저장
+        self.travelCurrency = travelCurrency // @Published 갱신
     }
     
     // MARK: userDefaults 조회 메서드


### PR DESCRIPTION
## 주요 내용

### Combine 기반 실시간 데이터 연동
- `SettingVC`에서 사용자가 기준 화폐, 여행 화폐를 변경하면, 해당 값이 Combine을 통해 `CalculateVC`에 즉시 반영되도록 구현했습니다.

### ViewModel 구조 개선
- `SettingVM`의 주요 설정 값에 `@Published`를 적용하여 값이 바뀔 때마다 자동으로 알림이 전달됩니다.
- `CalculateVC`에서는 이 값들을 구독하여, 설정이 변경될 때마다 UI와 계산 결과가 자동으로 최신화됩니다.

### UserDefaults 연동
- 설정 값 변경 시 UserDefaults에도 바로 저장되고, Combine을 통해 다른 화면에도 즉시 반영되도록 했습니다.
- 앱을 재실행해도 최신 설정이 유지됩니다.

### Combine을 선택한 이유
- 기존에 NotificationCenter와 Combine을 모두 검토했으나,  
  Combine은 Swift에서 공식적으로 지원하는 비동기/반응형 데이터 흐름 처리 방식으로  
  타입 안전성, 코드의 가독성, 유지보수 측면에서 더 큰 장점이 있다고 판단하여 도입하였습니다.
- MVVM 패턴과의 조합으로 ViewModel 간 데이터 전달이 더 명확해진다는 이점이 있습니다.

---

## 스크린샷
![Jun-08-2025 01-49-02](https://github.com/user-attachments/assets/967d8ee0-8978-4c62-84d1-1ddf4a9f5828)

---

### 이슈번호 : #33



 