### PR TITLE
Refactor: UI 통일 작업 완료

### DIFF
--- a/TaxRefundCalculator/Assets.xcassets/bgSecondary.colorset/Contents.json
+++ b/TaxRefundCalculator/Assets.xcassets/bgSecondary.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFB",
-          "green" : "0xFA",
-          "red" : "0xF9"
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/TaxRefundCalculator/Assets.xcassets/grayBtn.colorset/Contents.json
+++ b/TaxRefundCalculator/Assets.xcassets/grayBtn.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFB",
-          "green" : "0xFA",
-          "red" : "0xF9"
+          "blue" : "0x80",
+          "green" : "0x72",
+          "red" : "0x6B"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x27",
-          "green" : "0x18",
-          "red" : "0x11"
+          "blue" : "0x80",
+          "green" : "0x72",
+          "red" : "0x6B"
         }
       },
       "idiom" : "universal"

--- a/TaxRefundCalculator/Assets.xcassets/textForGreen.colorset/Contents.json
+++ b/TaxRefundCalculator/Assets.xcassets/textForGreen.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x27",
-          "green" : "0x18",
-          "red" : "0x11"
+          "blue" : "0xFB",
+          "green" : "0xFA",
+          "red" : "0xF9"
         }
       },
       "idiom" : "universal"

--- a/TaxRefundCalculator/CalculatePage/CalculateVC.swift
+++ b/TaxRefundCalculator/CalculatePage/CalculateVC.swift
@@ -27,7 +27,7 @@ class CalculateVC: UIViewController {
     // MARK: - 선택 통화, 환율 카드
     private let currencyRateCard = UIView().then {
         $0.backgroundColor = .bgSecondary
-        $0.layer.cornerRadius = 12
+        $0.layer.cornerRadius = 16
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.1
         $0.layer.shadowOffset = CGSize(width: 0, height: 4)
@@ -49,7 +49,7 @@ class CalculateVC: UIViewController {
     // MARK: - 구매금액 입력 카드
     private let priceCard = UIView().then {
         $0.backgroundColor = .bgSecondary
-        $0.layer.cornerRadius = 12
+        $0.layer.cornerRadius = 16
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.1
         $0.layer.shadowOffset = CGSize(width: 0, height: 4)
@@ -68,7 +68,7 @@ class CalculateVC: UIViewController {
         $0.backgroundColor = .subButton
         $0.borderStyle = .none // 기본 테두리를 제거
         $0.layer.borderWidth = 0.7 // 테두리 두께 설정
-        $0.layer.cornerRadius = 8 // 둥근 모서리 설정 (선택 사항)
+        $0.layer.cornerRadius = 12 // 둥근 모서리 설정 (선택 사항)
         $0.leftView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: 10.0, height: 0.0)) // 왼쪽 여백
         $0.leftViewMode = .always
         $0.rightView = textFieldLabel
@@ -78,14 +78,14 @@ class CalculateVC: UIViewController {
     private let calculateBtn = UIButton().then {
         $0.backgroundColor = .mainTeal
         $0.setTitle("계산하기", for: .normal)
-        $0.layer.cornerRadius = 8
+        $0.layer.cornerRadius = 12
         $0.addTarget(self, action: #selector(calculateBtnTapped), for: .touchUpInside)
     }
     
     // MARK: - 계산 카드
     private let calculateCard = UIView().then {
         $0.backgroundColor = .bgSecondary
-        $0.layer.cornerRadius = 12
+        $0.layer.cornerRadius = 16
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.1
         $0.layer.shadowOffset = CGSize(width: 0, height: 4)
@@ -153,13 +153,13 @@ class CalculateVC: UIViewController {
     private lazy var saveBtn = UIButton().then {
         $0.backgroundColor = .mainTeal
         $0.setTitle("+ 기록 저장", for: .normal)
-        $0.layer.cornerRadius = 8
+        $0.layer.cornerRadius = 12
         $0.addTarget(self, action: #selector(saveBtnTapped), for: .touchUpInside)
     }
     private lazy var checkBtn = UIButton().then {
         $0.backgroundColor = .grayBtn
         $0.setTitle("환급 조건 보기", for: .normal)
-        $0.layer.cornerRadius = 8
+        $0.layer.cornerRadius = 12
         $0.addTarget(self, action: #selector(checkBtnTapped), for: .touchUpInside)
     }
     private lazy var btnStackView = UIStackView(arrangedSubviews: [saveBtn, checkBtn]).then {
@@ -390,7 +390,7 @@ class CalculateVC: UIViewController {
         }
         btnStackView.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(20)
-            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview().inset(16)
             $0.height.equalTo(40)
         }
     }

--- a/TaxRefundCalculator/CalculatePage/CalculateVC.swift
+++ b/TaxRefundCalculator/CalculatePage/CalculateVC.swift
@@ -12,21 +12,21 @@ import Combine
 
 class CalculateVC: UIViewController {
     
-    // MARK: 뷰모델
+    // MARK: - 뷰모델
     private let viewModel = CalculateVM()
     
-    // MARK: 의존성 주입
+    // MARK: - 의존성 주입
     private let settingVM = SettingVM.shared
     private var cancellables = Set<AnyCancellable>() // Combine 구독관리
 
-    // MARK: 사이즈 대응을 위한 스크롤 뷰
+    // MARK: - 사이즈 대응을 위한 스크롤 뷰
     let scrollView = UIScrollView()
     let scrollContentView = UIView()
 
     
-    // MARK: 선택 통화, 환율 카드
+    // MARK: - 선택 통화, 환율 카드
     private let currencyRateCard = UIView().then {
-        $0.backgroundColor = .bgPrimary
+        $0.backgroundColor = .bgSecondary
         $0.layer.cornerRadius = 12
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.1
@@ -46,9 +46,9 @@ class CalculateVC: UIViewController {
     private var currency2Num = 999
     private var currency2 = "화폐2"
     
-    // MARK: 구매금액 입력 카드
+    // MARK: - 구매금액 입력 카드
     private let priceCard = UIView().then {
-        $0.backgroundColor = .bgPrimary
+        $0.backgroundColor = .bgSecondary
         $0.layer.cornerRadius = 12
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.1
@@ -82,9 +82,9 @@ class CalculateVC: UIViewController {
         $0.addTarget(self, action: #selector(calculateBtnTapped), for: .touchUpInside)
     }
     
-    // MARK: 계산 카드
+    // MARK: - 계산 카드
     private let calculateCard = UIView().then {
-        $0.backgroundColor = .bgPrimary
+        $0.backgroundColor = .bgSecondary
         $0.layer.cornerRadius = 12
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.1
@@ -157,7 +157,7 @@ class CalculateVC: UIViewController {
         $0.addTarget(self, action: #selector(saveBtnTapped), for: .touchUpInside)
     }
     private lazy var checkBtn = UIButton().then {
-        $0.backgroundColor = .currency
+        $0.backgroundColor = .grayBtn
         $0.setTitle("환급 조건 보기", for: .normal)
         $0.layer.cornerRadius = 8
         $0.addTarget(self, action: #selector(checkBtnTapped), for: .touchUpInside)
@@ -178,7 +178,7 @@ class CalculateVC: UIViewController {
         keyboardDown()
     }
     
-    // MARK: Combine으로 기준 화폐, 여행화폐 최신화
+    // MARK: - Combine으로 기준 화폐, 여행화폐 최신화
     private func updateFromSetting() {
         // 기준 화폐 값 구독 (SettingVM의 baseCurrency가 바뀌면 이 코드가 실행됨)
         settingVM.$baseCurrency
@@ -214,7 +214,7 @@ class CalculateVC: UIViewController {
     }
     
     
-    // MARK: UserDefaults에서 값 불러오기
+    // MARK: - UserDefaults에서 값 불러오기
     private func loadFromUserdefaults() {
         // 여행국가화폐 불러오기
         if let savedTravelCountry = viewModel.getTravelCountry3() {
@@ -241,9 +241,9 @@ class CalculateVC: UIViewController {
     }
     
     
-    // MARK: UI 구성
+    // MARK: - UI 구성
     private func configureUI() {
-        view.backgroundColor = .bgSecondary
+        view.backgroundColor = .bgPrimary
         
         
         // MARK: 사이즈 대응을 위한 스크롤 뷰

--- a/TaxRefundCalculator/ExchangePage/ExchangeCell.swift
+++ b/TaxRefundCalculator/ExchangePage/ExchangeCell.swift
@@ -37,8 +37,8 @@ final class ExchangeCell: UITableViewCell {
     // MARK: - Layout
     
     private func setupUI() {
-        backgroundColor = .bgPrimary
-        contentView.backgroundColor = .bgPrimary
+        backgroundColor = .bgSecondary
+        contentView.backgroundColor = .bgSecondary
         
         contentView.addSubviews(flagLabel, currencyCodeLabel,
                                 priceLabel)

--- a/TaxRefundCalculator/ExchangePage/ExchangeView.swift
+++ b/TaxRefundCalculator/ExchangePage/ExchangeView.swift
@@ -33,6 +33,16 @@ final class ExchangeView: UIView {
         $0.clipsToBounds = true
         $0.allowsSelection = false
     }
+    
+    private let tableContainerView = UIView().then {
+        $0.backgroundColor = .clear
+        $0.layer.cornerRadius = 16
+        $0.layer.shadowColor = UIColor.black.cgColor
+        $0.layer.shadowOpacity = 0.1
+        $0.layer.shadowOffset = CGSize(width: 0, height: 4)
+        $0.layer.shadowRadius = 6
+        $0.clipsToBounds = false
+    }
 
     // MARK: - Init
 
@@ -49,7 +59,9 @@ final class ExchangeView: UIView {
 
     private func setupUI() {
         backgroundColor = .bgPrimary
-        addSubviews(titleLabel, refreshLabel, tableView)
+        addSubviews(titleLabel, refreshLabel, tableContainerView)
+        tableContainerView.addSubview(tableView)
+
 
         titleLabel.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide).inset(16)
@@ -60,11 +72,16 @@ final class ExchangeView: UIView {
             $0.centerY.equalTo(titleLabel)
             $0.trailing.equalToSuperview().inset(16)
         }
-
-        tableView.snp.makeConstraints {
+        
+        tableContainerView.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(12)
             $0.horizontalEdges.equalToSuperview().inset(16)
             $0.bottom.equalTo(safeAreaLayoutGuide).inset(16)
         }
+        
+        tableView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
     }
 }

--- a/TaxRefundCalculator/ExchangePage/ExchangeView.swift
+++ b/TaxRefundCalculator/ExchangePage/ExchangeView.swift
@@ -16,7 +16,7 @@ final class ExchangeView: UIView {
     private let titleLabel = UILabel().then {
         $0.text = "실시간 환율정보"
         $0.font = .systemFont(ofSize: 18, weight: .medium)
-        $0.textColor = .bodyText
+        $0.textColor = .primaryText
     }
     
     let refreshLabel = UILabel().then {
@@ -27,7 +27,7 @@ final class ExchangeView: UIView {
     let tableView = UITableView().then {
         $0.separatorStyle = .singleLine
         $0.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-        $0.backgroundColor = .bgPrimary
+        $0.backgroundColor = .bgSecondary
         $0.rowHeight = 52
         $0.layer.cornerRadius = 16
         $0.clipsToBounds = true
@@ -48,7 +48,7 @@ final class ExchangeView: UIView {
     // MARK: - Setup
 
     private func setupUI() {
-        backgroundColor = .subButton
+        backgroundColor = .bgPrimary
         addSubviews(titleLabel, refreshLabel, tableView)
 
         titleLabel.snp.makeConstraints {

--- a/TaxRefundCalculator/Modals/RefundModal.swift
+++ b/TaxRefundCalculator/Modals/RefundModal.swift
@@ -31,7 +31,7 @@ class RefundModal: UIViewController {
     private let closeBtn = UIButton().then {
         $0.setTitle("닫기", for: .normal)
         $0.backgroundColor = .mainTeal
-        $0.layer.cornerRadius = 15
+        $0.layer.cornerRadius = 12
         $0.addTarget(self, action: #selector(closeBtnTapped), for: .touchUpInside)
     }
     private let flagLabel = UILabel().then {
@@ -102,7 +102,7 @@ class RefundModal: UIViewController {
         closeBtn.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(30)
             $0.leading.trailing.equalToSuperview().inset(25)
-            $0.height.equalTo(55)
+            $0.height.equalTo(48)
         }
         
         containerView.addSubview(scrollView)

--- a/TaxRefundCalculator/Modals/RefundModal.swift
+++ b/TaxRefundCalculator/Modals/RefundModal.swift
@@ -16,7 +16,7 @@ class RefundModal: UIViewController {
     let viewModel = CalculateVM()
     
     private let containerView = UIView().then {
-        $0.backgroundColor = .white
+        $0.backgroundColor = .bgSecondary
         $0.layer.cornerRadius = 16
         $0.clipsToBounds = true
     }

--- a/TaxRefundCalculator/Models/RefundCondition.swift
+++ b/TaxRefundCalculator/Models/RefundCondition.swift
@@ -28,11 +28,11 @@ let koreaPolicy = VATRefundPolicy(
     vatRefund: 0.07,
     minimumAmount: 15000.0,
     refundRateDescription: "구매 금액의 최대 7%",
-    eligibleBuyers: "한국에 6개월 미만 체류한 외국인, 한국에 3개월 미만 체류하며 해외에 2년 이상 거주한 해외 교포",
+    eligibleBuyers: "6개월 미만 체류 외국인, 3개월 미만 체류하며 해외에 2년 이상 거주한 해외 교포",
     eligibleItems: "미개봉 및 미사용 상태의 과세 물품, 구매일로부터 3개월 이내에 출국 시 반출하는 물품",
-    refundMethod: "즉시 환급: 일부 매장에서 구매 시 즉시 세금 차감, 시내 환급: 도심 환급소에서 환급, 공항 환급: 출국 시 공항 환급소 또는 키오스크에서 환급",
+    refundMethod: "즉시 환급, 시내 도심 환급소 환급, 공항 환급",
     refundPlace: "인천국제공항 및 주요 공항의 환급 카운터 또는 키오스크, 서울 등 주요 도시의 시내 환급소",
-    notes: "환급 금액은 구매 금액의 최대 약 7%까지 가능하며, 환급 수수료 및 환율 변동에 따라 실제 환급액은 달라질 수 있습니다. 세관에서 구매 물품에 대한 확인 도장을 받아야 합니다."
+    notes: "세관에서 구매 물품에 대한 확인 도장을 받아야 함."
 )
 
 let japanPolicy = VATRefundPolicy(

--- a/TaxRefundCalculator/SavedPage/SavedCardCell.swift
+++ b/TaxRefundCalculator/SavedPage/SavedCardCell.swift
@@ -23,9 +23,9 @@ final class SavedCardCell: UITableViewCell {
         $0.backgroundColor = .bgSecondary
         $0.layer.cornerRadius = 12
         $0.layer.shadowColor = UIColor.black.cgColor
-        $0.layer.shadowOpacity = 0.05
-        $0.layer.shadowOffset = CGSize(width: 0, height: 2)
-        $0.layer.shadowRadius = 4
+        $0.layer.shadowOpacity = 0.1
+        $0.layer.shadowOffset = CGSize(width: 0, height: 4)
+        $0.layer.shadowRadius = 6
     }
     
     // 나라이름

--- a/TaxRefundCalculator/SavedPage/SavedCardCell.swift
+++ b/TaxRefundCalculator/SavedPage/SavedCardCell.swift
@@ -20,7 +20,7 @@ final class SavedCardCell: UITableViewCell {
     private var deleteHandler: (() -> Void)?
     
     private let cardView = UIView().then {
-        $0.backgroundColor = .bgPrimary
+        $0.backgroundColor = .bgSecondary
         $0.layer.cornerRadius = 12
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.05
@@ -109,8 +109,9 @@ final class SavedCardCell: UITableViewCell {
     }
     
     private func setupUI() {
-        backgroundColor = .subButton
-        contentView.backgroundColor = .subButton
+        selectionStyle = .none
+        backgroundColor = .bgSecondary
+        contentView.backgroundColor = .bgPrimary
         
         contentView.addSubview(cardView)
         cardView.addSubviews(

--- a/TaxRefundCalculator/SavedPage/SavedModalVC.swift
+++ b/TaxRefundCalculator/SavedPage/SavedModalVC.swift
@@ -23,7 +23,7 @@ final class SavedModalVC: UIViewController {
     // MARK: - UI Components
     
     private let containerView = UIView().then {
-        $0.backgroundColor = .bgPrimary
+        $0.backgroundColor = .bgSecondary
         $0.layer.cornerRadius = 20
     }
     
@@ -38,13 +38,13 @@ final class SavedModalVC: UIViewController {
     // 날짜
     private let dateLabel = UILabel().then {
         $0.font = .systemFont(ofSize: 14, weight: .light)
-        $0.textColor = .currency
+        $0.textColor = .primaryText
     }
     
     private let purchaseTitleLabel = UILabel().then {
         $0.text = "구매 금액"
         $0.font = .systemFont(ofSize: 14)
-        $0.textColor = .currency
+        $0.textColor = .primaryText
     }
     
     private let purchaseAmountLabel = UILabel().then {
@@ -58,7 +58,7 @@ final class SavedModalVC: UIViewController {
     private let refundTitleLabel = UILabel().then {
         $0.font = .systemFont(ofSize: 14, weight: .medium)
         $0.text = "환급 금액"
-        $0.textColor = .currency
+        $0.textColor = .primaryText
     }
     
     private let refundAmountLabel = UILabel().then {
@@ -85,12 +85,12 @@ final class SavedModalVC: UIViewController {
     private let rateLabel = UILabel().then {
         $0.font = .systemFont(ofSize: 15, weight: .medium)
         $0.text = "적용된 환율 :"
-        $0.textColor = .currency
+        $0.textColor = .primaryText
     }
     
     private let exchangeRateLabel = UILabel().then {
         $0.font = .systemFont(ofSize: 15, weight: .medium)
-        $0.textColor = .currency
+        $0.textColor = .primaryText
     }
     
     private let conditionLabel = UILabel().then {
@@ -102,7 +102,7 @@ final class SavedModalVC: UIViewController {
     private let dismissButton = UIButton(type: .system).then {
         $0.setTitle("닫기", for: .normal)
         $0.setTitleColor(.white, for: .normal)
-        $0.backgroundColor = .currency
+        $0.backgroundColor = .mainTeal
         $0.titleLabel?.font = .systemFont(ofSize: 16, weight: .medium)
         $0.layer.cornerRadius = 10
     }

--- a/TaxRefundCalculator/SavedPage/SavedView.swift
+++ b/TaxRefundCalculator/SavedPage/SavedView.swift
@@ -19,30 +19,30 @@ final class SavedView: UIView {
 
     let totalPurchaseLabel = UILabel().then {
         $0.text = "총 구매 금액"
-        $0.textColor = .bgPrimary
+        $0.textColor = .textForGreen
         $0.font = .systemFont(ofSize: 14)
     }
 
     let totalRefundLabel = UILabel().then {
         $0.text = "총 환급 금액"
-        $0.textColor = .bgPrimary
+        $0.textColor = .textForGreen
         $0.font = .systemFont(ofSize: 14)
     }
 
     let totalPurchaseAmountLabel = UILabel().then {
         $0.text = "0"
-        $0.textColor = .bgPrimary
+        $0.textColor = .textForGreen
         $0.font = .boldSystemFont(ofSize: 20)
     }
 
     let totalRefundAmountLabel = UILabel().then {
         $0.text = "0"
-        $0.textColor = .bgPrimary
+        $0.textColor = .textForGreen
         $0.font = .boldSystemFont(ofSize: 20)
     }
 
     let dividerView = UIView().then {
-        $0.backgroundColor = UIColor.bgPrimary.withAlphaComponent(0.5)
+        $0.backgroundColor = UIColor.textForGreen.withAlphaComponent(0.5)
     }
     
     // 총 구매 금액 스택
@@ -59,7 +59,7 @@ final class SavedView: UIView {
     }
 
     let filterContainer = UIView().then {
-        $0.backgroundColor = .bgPrimary
+        $0.backgroundColor = .bgSecondary
         $0.layer.cornerRadius = 12
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.05
@@ -83,7 +83,7 @@ final class SavedView: UIView {
     // 기록 리스트
     let tableView = UITableView().then {
         $0.separatorStyle = .none
-        $0.backgroundColor = .subButton
+        $0.backgroundColor = .bgPrimary
     }
 
     override init(frame: CGRect) {
@@ -96,7 +96,7 @@ final class SavedView: UIView {
     }
 
     private func setupUI() {
-        backgroundColor = .subButton
+        backgroundColor = .bgPrimary
 
         addSubviews(totalContainer, filterContainer, tableView)
         filterContainer.addSubviews(dateRangeLabel, changeButton)

--- a/TaxRefundCalculator/SettingPage/SettingVC.swift
+++ b/TaxRefundCalculator/SettingPage/SettingVC.swift
@@ -16,7 +16,7 @@ class SettingVC: UIViewController, LanguageModalDelegate, CountryModalDelegate {
     // MARK: 앱 설정 카드
     private let settingCard = UIView().then {
         $0.backgroundColor = .bgSecondary
-        $0.layer.cornerRadius = 12
+        $0.layer.cornerRadius = 16
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.1
         $0.layer.shadowOffset = CGSize(width: 0, height: 4)
@@ -100,7 +100,7 @@ class SettingVC: UIViewController, LanguageModalDelegate, CountryModalDelegate {
     // MARK: 앱 정보 카드
     private let infoCard = UIView().then {
         $0.backgroundColor = .bgSecondary
-        $0.layer.cornerRadius = 12
+        $0.layer.cornerRadius = 16
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.1
         $0.layer.shadowOffset = CGSize(width: 0, height: 4)
@@ -128,16 +128,6 @@ class SettingVC: UIViewController, LanguageModalDelegate, CountryModalDelegate {
     }
     private let updateDay = UILabel().then {
         $0.text = "2025.05.11"
-        $0.font = UIFont.systemFont(ofSize: 17, weight: .thin)
-        $0.textColor = .subText
-    }
-    private let developer = UILabel().then {
-        $0.text = "개발자"
-        $0.font = UIFont.systemFont(ofSize: 17, weight: .thin)
-        $0.textColor = .subText
-    }
-    private let developerName = UILabel().then {
-        $0.text = "이재건, 나영진"
         $0.font = UIFont.systemFont(ofSize: 17, weight: .thin)
         $0.textColor = .subText
     }
@@ -302,7 +292,7 @@ class SettingVC: UIViewController, LanguageModalDelegate, CountryModalDelegate {
         infoCard.snp.makeConstraints {
             $0.top.equalTo(settingCard.snp.bottom).offset(16)
             $0.leading.trailing.equalToSuperview().inset(16)
-            $0.height.equalTo(160)
+            $0.height.equalTo(130)
         }
         
         infoCard.addSubview(infoLabel)
@@ -310,8 +300,6 @@ class SettingVC: UIViewController, LanguageModalDelegate, CountryModalDelegate {
         infoCard.addSubview(versionNumber)
         infoCard.addSubview(update)
         infoCard.addSubview(updateDay)
-        infoCard.addSubview(developer)
-        infoCard.addSubview(developerName)
         
         infoLabel.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(16)
@@ -332,14 +320,6 @@ class SettingVC: UIViewController, LanguageModalDelegate, CountryModalDelegate {
         updateDay.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(16)
             $0.top.equalTo(version.snp.bottom).offset(11)
-        }
-        developer.snp.makeConstraints {
-            $0.leading.equalToSuperview().inset(30)
-            $0.top.equalTo(update.snp.bottom).offset(11)
-        }
-        developerName.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(16)
-            $0.top.equalTo(updateDay.snp.bottom).offset(11)
         }
         
     }

--- a/TaxRefundCalculator/SettingPage/SettingVC.swift
+++ b/TaxRefundCalculator/SettingPage/SettingVC.swift
@@ -15,7 +15,7 @@ class SettingVC: UIViewController, LanguageModalDelegate, CountryModalDelegate {
     
     // MARK: 앱 설정 카드
     private let settingCard = UIView().then {
-        $0.backgroundColor = .bgPrimary
+        $0.backgroundColor = .bgSecondary
         $0.layer.cornerRadius = 12
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.1
@@ -99,7 +99,7 @@ class SettingVC: UIViewController, LanguageModalDelegate, CountryModalDelegate {
     
     // MARK: 앱 정보 카드
     private let infoCard = UIView().then {
-        $0.backgroundColor = .bgPrimary
+        $0.backgroundColor = .bgSecondary
         $0.layer.cornerRadius = 12
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.1
@@ -171,7 +171,7 @@ class SettingVC: UIViewController, LanguageModalDelegate, CountryModalDelegate {
     
     
     private func configureUI() {
-        view.backgroundColor = .bgSecondary
+        view.backgroundColor = .bgPrimary
         
         // MARK: Setting Card
         view.addSubview(settingCard)

--- a/TaxRefundCalculator/StartPage/StartPageVC.swift
+++ b/TaxRefundCalculator/StartPage/StartPageVC.swift
@@ -47,7 +47,7 @@ class StartPageVC: UIViewController, UITextFieldDelegate, CountryModalDelegate, 
     
     // MARK: 언어 선택 카드
     private let languageCard = UIView().then {
-        $0.backgroundColor = .bgPrimary
+        $0.backgroundColor = .bgSecondary
         $0.layer.cornerRadius = 15
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.1
@@ -62,7 +62,7 @@ class StartPageVC: UIViewController, UITextFieldDelegate, CountryModalDelegate, 
     }
     private let languageField = UITextField().then {
         $0.placeholder = "언어를 선택하세요."
-        $0.backgroundColor = .subButton
+        $0.backgroundColor = .bgPrimary
         $0.borderStyle = .none // 기본 테두리를 제거
         $0.layer.borderWidth = 0.7 // 테두리 두께 설정
         $0.layer.cornerRadius = 8 // 둥근 모서리 설정 (선택 사항)
@@ -74,7 +74,7 @@ class StartPageVC: UIViewController, UITextFieldDelegate, CountryModalDelegate, 
     
     // MARK: 기준 통화 선택, 여행국가 선택 카드
     private let currencyCard = UIView().then {
-        $0.backgroundColor = .bgPrimary
+        $0.backgroundColor = .bgSecondary
         $0.layer.cornerRadius = 15
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.1
@@ -90,7 +90,7 @@ class StartPageVC: UIViewController, UITextFieldDelegate, CountryModalDelegate, 
     }
     let baseCurrencyField = UITextField().then {
         $0.placeholder = "기준화폐를 선택하세요."
-        $0.backgroundColor = .subButton
+        $0.backgroundColor = .bgPrimary
         $0.borderStyle = .none // 기본 테두리를 제거
         $0.layer.borderWidth = 0.7 // 테두리 두께 설정
         $0.layer.cornerRadius = 8 // 둥근 모서리 설정 (선택 사항)
@@ -106,7 +106,7 @@ class StartPageVC: UIViewController, UITextFieldDelegate, CountryModalDelegate, 
     }
     private let travelCountryField = UITextField().then {
         $0.placeholder = "여행국가를 선택하세요."
-        $0.backgroundColor = .subButton
+        $0.backgroundColor = .bgPrimary
         $0.borderStyle = .none // 기본 테두리를 제거
         $0.layer.borderWidth = 0.7 // 테두리 두께 설정
         $0.layer.cornerRadius = 8 // 둥근 모서리 설정 (선택 사항)
@@ -118,7 +118,7 @@ class StartPageVC: UIViewController, UITextFieldDelegate, CountryModalDelegate, 
     
     // MARK: 환율 정보 카드
     private let exchangeRateCard = UIView().then {
-        $0.backgroundColor = .bgPrimary
+        $0.backgroundColor = .bgSecondary
         $0.layer.cornerRadius = 15
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.1
@@ -139,7 +139,7 @@ class StartPageVC: UIViewController, UITextFieldDelegate, CountryModalDelegate, 
     
     // MARK: 환급 조건 카드
     private let conditionCard = UIView().then {
-        $0.backgroundColor = .bgPrimary
+        $0.backgroundColor = .bgSecondary
         $0.layer.cornerRadius = 15
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.1
@@ -181,7 +181,7 @@ class StartPageVC: UIViewController, UITextFieldDelegate, CountryModalDelegate, 
     }
     
     private func configureUI() {
-        view.backgroundColor = .bgSecondary
+        view.backgroundColor = .bgPrimary
         
         // MARK: Labels
         view.addSubview(titleLabel) // "택스리펀 환급금 예상 계산기"

--- a/TaxRefundCalculator/en.lproj/Localizable.strings
+++ b/TaxRefundCalculator/en.lproj/Localizable.strings
@@ -1,0 +1,788 @@
+///* 
+//  Localizable.strings
+//  TaxRefundCalculator
+//
+//  Created by 이재건 on 6/23/25.
+//  
+//*/
+//
+//// MARK: 시작화면
+//// 영어
+//"Tax Refund Calculator"
+//"Calculate your tax refund amount in advance."
+//"Select Language"
+//"Please select a language."
+//"Select Base Currency"
+//"Please select a base currency."
+//"Select Travel Country"
+//"Please select a travel country."
+//"Exchange Rate Info"
+//"Please select a currency and a country."
+//"Refund Policy"
+//"Please select a travel country."
+//"Start →"
+//// 모달
+//"Input Confirmation"
+//"Please select all items."
+//"OK"
+//
+//
+//// 한국어
+//"택스리펀 환급금 예상 계산기"
+//"해외 쇼핑 시 세금 환급 금액을 미리 계산해보세요."
+//"언어 선택"
+//"언어를 선택하세요."
+//"기준 통화 선택"
+//"기준화폐를 선택하세요."
+//"여행국가 선택"
+//"여행국가를 선택하세요."
+//"환율 정보"
+//"화폐, 국가 선택이 필요합니다."
+//"환급 조건"
+//"여행국가를 선택해 주세요."
+//"시작하기 →"
+//// 모달
+//"입력 확인"
+//"모든 항목을 선택해 주세요."
+//"확인"
+//
+//
+//// 일본어
+//"免税払い戻し金額計算機"
+//"海外ショッピングの税金還付額を事前に計算できます。"
+//"言語を選択"
+//"言語を選択してください。"
+//"基準通貨を選択"
+//"基準通貨を選択してください。"
+//"渡航国を選択"
+//"渡航国を選択してください。"
+//"為替情報"
+//"通貨と国の選択が必要です。"
+//"還付条件"
+//"渡航国を選択してください。"
+//"開始する →"
+//// 모달
+//"入力確認"
+//"すべての項目を選択してください。"
+//"確認"
+//
+//
+//// 스페인어
+//"Calculadora de devolución de impuestos"
+//"Calcula por adelantado el importe de tu reembolso de impuestos por compras en el extranjero."
+//"Seleccionar idioma"
+//"Por favor, selecciona un idioma."
+//"Seleccionar moneda base"
+//"Por favor, selecciona una moneda base."
+//"Seleccionar país de destino"
+//"Por favor, selecciona el país de destino."
+//"Información sobre el tipo de cambio"
+//"Es necesario seleccionar la moneda y el país."
+//"Condiciones de devolución"
+//"Por favor, selecciona el país de destino."
+//"Empezar →"
+//// 모달
+//"Confirmación de entrada"
+//"Por favor, selecciona todos los elementos."
+//"Aceptar"
+//
+//
+//// 프랑스어
+//"Calculateur de remboursement de taxes"
+//"Calculez à l’avance le montant de votre remboursement de taxes pour les achats à l’étranger."
+//"Choisir la langue"
+//"Veuillez choisir une langue."
+//"Choisir la devise de base"
+//"Veuillez choisir une devise de base."
+//"Choisir le pays de destination"
+//"Veuillez choisir le pays de destination."
+//"Informations sur le taux de change"
+//"Veuillez choisir une devise et un pays."
+//"Conditions de remboursement"
+//"Veuillez choisir le pays de destination."
+//"Commencer →"
+//// 모달
+//"Confirmation de saisie"
+//"Veuillez sélectionner tous les éléments."
+//"OK"
+//
+//
+//// 독일어
+//"Steuerrückerstattungsrechner"
+//"Berechnen Sie im Voraus Ihren Steuererstattungsbetrag für Einkäufe im Ausland."
+//"Sprache auswählen"
+//"Bitte wählen Sie eine Sprache aus."
+//"Basiswährung auswählen"
+//"Bitte wählen Sie eine Basiswährung aus."
+//"Reiseland auswählen"
+//"Bitte wählen Sie ein Reiseland aus."
+//"Wechselkursinformation"
+//"Bitte wählen Sie eine Währung und ein Land aus."
+//"Erstattungsbedingungen"
+//"Bitte wählen Sie ein Reiseland aus."
+//"Starten →"
+//// 모달
+//"Eingabebestätigung"
+//"Bitte wählen Sie alle Felder aus."
+//"OK"
+//
+//
+//// 이탈리아
+//"Calcolatore rimborso fiscale"
+//"Calcola in anticipo l’importo del rimborso fiscale per acquisti all’estero."
+//"Seleziona lingua"
+//"Seleziona una lingua."
+//"Seleziona valuta di base"
+//"Seleziona una valuta di base."
+//"Seleziona paese di viaggio"
+//"Seleziona il paese di viaggio."
+//"Informazioni sul tasso di cambio"
+//"È necessario selezionare valuta e paese."
+//"Condizioni di rimborso"
+//"Seleziona il paese di viaggio."
+//"Inizia →"
+//// 모달
+//"Conferma inserimento"
+//"Seleziona tutti gli elementi."
+//"OK"
+//
+//
+//// 러시아어
+//"Калькулятор возврата налога"
+//"Рассчитайте сумму возврата налога при покупках за границей заранее."
+//"Выбрать язык"
+//"Пожалуйста, выберите язык."
+//"Выбрать базовую валюту"
+//"Пожалуйста, выберите базовую валюту."
+//"Выбрать страну поездки"
+//"Пожалуйста, выберите страну поездки."
+//"Информация о курсе валют"
+//"Требуется выбрать валюту и страну."
+//"Условия возврата"
+//"Пожалуйста, выберите страну поездки."
+//"Начать →"
+//// 모달
+//"Подтверждение ввода"
+//"Пожалуйста, выберите все пункты."
+//"ОК"
+//
+//
+//// MARK: 계산화면
+//// 영어
+//"Enter purchase amount"
+//"Please enter numbers only."
+//"Calculate"
+//"VAT Rate"
+//"Purchase Amount"
+//"Approx. 0"
+//"Estimated Refund Amount"
+//"Approx. 0"
+//"Save Record"
+//"View Refund Policy"
+//"Calculate"
+//"History"
+//"Exchange Rate"
+//"Settings"
+//"Close"
+//
+//// 한국어
+//"구매 금액 입력"
+//"숫자만 입력해주세요."
+//"계산하기"
+//"부가세율(VAT)"
+//"구매금액"
+//"약 0 KRW"
+//"예상 환급 금액"
+//"약 0 KRW"
+//"기록 저장"
+//"환급 조건 보기"
+//"계산"
+//"기록"
+//"환율"
+//"설정"
+//"닫기"
+//
+//// 일본어
+//"購入金額を入力"
+//"数字のみ入力してください。"
+//"計算する"
+//"消費税率（VAT）"
+//"購入金額"
+//"約 0"
+//"推定還付金額"
+//"約 0"
+//"記録を保存"
+//"還付条件を見る"
+//"計算"
+//"履歴"
+//"為替"
+//"設定"
+//"閉じる"
+//
+//// 스페인어
+//"Introduce el importe de la compra"
+//"Por favor, introduce solo números."
+//"Calcular"
+//"Tasa de IVA"
+//"Importe de la compra"
+//"Aproximadamente 0"
+//"Importe estimado del reembolso"
+//"Aproximadamente 0"
+//"Guardar registro"
+//"Ver condiciones de reembolso"
+//"Calcular"
+//"Historial"
+//"Tipo de cambio"
+//"Configuración"
+//"Cerrar"
+//
+//// 독일어
+//"Kaufbetrag eingeben"
+//"Bitte nur Zahlen eingeben."
+//"Berechnen"
+//"Mehrwertsteuersatz (MwSt)"
+//"Kaufbetrag"
+//"Ca. 0"
+//"Geschätzter Rückerstattungsbetrag"
+//"Ca. 0"
+//"Eintrag speichern"
+//"Erstattungsbedingungen anzeigen"
+//"Berechnen"
+//"Verlauf"
+//"Wechselkurs"
+//"Einstellungen"
+//"Schließen"
+//
+//// 이탈리아어
+//"Inserisci l’importo dell’acquisto"
+//"Inserisci solo numeri, per favore."
+//"Calcola"
+//"Aliquota IVA"
+//"Importo dell’acquisto"
+//"Circa 0"
+//"Importo stimato del rimborso"
+//"Circa 0"
+//"Salva registrazione"
+//"Visualizza condizioni di rimborso"
+//"Calcola"
+//"Storico"
+//"Tasso di cambio"
+//"Impostazioni"
+//"Chiudi"
+//
+//// 프랑스어
+//"Saisir le montant de l’achat"
+//"Veuillez entrer uniquement des chiffres."
+//"Calculer"
+//"Taux de TVA"
+//"Montant de l’achat"
+//"Env. 0"
+//"Montant estimé du remboursement"
+//"Env. 0"
+//"Enregistrer"
+//"Voir les conditions de remboursement"
+//"Calculer"
+//"Historique"
+//"Taux de change"
+//"Paramètres"
+//"Fermer"
+//
+//// 러시아어
+//"Введите сумму покупки"
+//"Пожалуйста, введите только цифры."
+//"Рассчитать"
+//"Ставка НДС"
+//"Сумма покупки"
+//"Примерно 0"
+//"Ожидаемая сумма возврата"
+//"Примерно 0"
+//"Сохранить запись"
+//"Посмотреть условия возврата"
+//"Расчет"
+//"История"
+//"Курс валют"
+//"Настройки"
+//"Закрыть"
+//
+//// 영어
+//"Input Error"
+//"You cannot enter blank spaces."
+//"OK"
+//
+//// 한국어
+//"입력 오류"
+//"공백은 입력할 수 없습니다."
+//"확인"
+//
+//// 일본어
+//"入力エラー"
+//"空白は入力できません。"
+//"確認"
+//
+//// 스페인어
+//"Error de entrada"
+//"No se pueden introducir espacios en blanco."
+//"Aceptar"
+//
+//// 독일어
+//"Eingabefehler"
+//"Leerzeichen können nicht eingegeben werden."
+//"OK"
+//
+//// 이탈리아어
+//"Errore di inserimento"
+//"Non è possibile inserire spazi vuoti."
+//"OK"
+//
+//// 프랑스어
+//"Erreur de saisie"
+//"Les espaces vides ne peuvent pas être saisis."
+//"OK"
+//
+//// 러시아어
+//"Ошибка ввода"
+//"Нельзя вводить пробелы."
+//"ОК"
+//
+//
+//// 영어
+//"Input Error"
+//"Only numbers and decimal points are allowed, and the decimal point can be entered only once."
+//"OK"
+//
+//// 한국어
+//"입력 오류"
+//"숫자와 소수점만, 그리고 소수점은 한 번만 입력할 수 있습니다."
+//"확인"
+//
+//// 일본어
+//"入力エラー"
+//"数字と小数点のみ入力でき、小数点は一度だけ入力できます。"
+//"確認"
+//
+//// 스페인어
+//"Error de entrada"
+//"Solo se permiten números y un solo punto decimal."
+//"Aceptar"
+//
+//// 독일어
+//"Eingabefehler"
+//"Es sind nur Zahlen und ein Dezimalpunkt erlaubt, und der Dezimalpunkt darf nur einmal eingegeben werden."
+//"OK"
+//
+//// 이탈리아어
+//"Errore di inserimento"
+//"Sono consentiti solo numeri e un solo punto decimale."
+//"OK"
+//
+//// 프랑스어
+//"Erreur de saisie"
+//"Seuls les chiffres et un seul point décimal sont autorisés."
+//"OK"
+//
+//// 러시아어
+//"Ошибка ввода"
+//"Разрешены только цифры и одна десятичная точка."
+//"ОК"
+//
+//
+//// 영어
+//"Save Complete"
+//"Saved successfully."
+//"OK"
+//
+//// 한국어
+//"저장 완료"
+//"저장이 완료되었습니다."
+//"확인"
+//
+//// 일본어
+//"保存完了"
+//"保存が完了しました。"
+//"確認"
+//
+//// 스페인어
+//"Guardado completado"
+//"Se ha guardado correctamente."
+//"Aceptar"
+//
+//// 독일어
+//"Speicherung abgeschlossen"
+//"Die Speicherung wurde abgeschlossen."
+//"OK"
+//
+//// 이탈리아어
+//"Salvataggio completato"
+//"Il salvataggio è stato completato."
+//"OK"
+//
+//// 프랑스어
+//"Enregistrement terminé"
+//"L’enregistrement a été effectué avec succès."
+//"OK"
+//
+//// 러시아어
+//"Сохранение завершено"
+//"Сохранение выполнено успешно."
+//"ОК"
+//
+//
+//// 영어
+//"VAT Rate:"
+//"Minimum Purchase Amount:"
+//"Refund Method:"
+//"Refund Location:"
+//"Notes:"
+//
+//// 한국어
+//"부가세율:"
+//"최소 구매금액:"
+//"환급 방법:"
+//"환급장소:"
+//"비고:"
+//
+//// 일본어
+//"消費税率："
+//"最低購入金額："
+//"還付方法："
+//"還付場所："
+//"備考："
+//
+//// 스페인어
+//"Tasa de IVA:"
+//"Importe mínimo de compra:"
+//"Método de reembolso:"
+//"Lugar de reembolso:"
+//"Notas:"
+//
+//// 독일어
+//"Mehrwertsteuersatz (MwSt):"
+//"Mindestkaufbetrag:"
+//"Erstattungsmethode:"
+//"Erstattungsstelle:"
+//"Hinweise:"
+//
+//// 이탈리아어
+//"Aliquota IVA:"
+//"Importo minimo d’acquisto:"
+//"Metodo di rimborso:"
+//"Luogo di rimborso:"
+//"Note:"
+//
+//// 프랑스어
+//"Taux de TVA :"
+//"Montant d’achat minimum :"
+//"Méthode de remboursement :"
+//"Lieu de remboursement :"
+//"Remarques :"
+//
+//// 러시아어
+//"Ставка НДС:"
+//"Минимальная сумма покупки:"
+//"Способ возврата:"
+//"Место возврата:"
+//"Примечания:"
+//
+//
+//// 영어
+//"Close"
+//
+//// 한국어
+//"닫기"
+//
+//// 일본어
+//"閉じる"
+//
+//// 스페인어
+//"Cerrar"
+//
+//// 독일어
+//"Schließen"
+//
+//// 이탈리아어
+//"Chiudi"
+//
+//// 프랑스어
+//"Fermer"
+//
+//// 러시아어
+//"Закрыть"
+//
+//
+//// MARK: 기록화면
+//// 영어
+//"Total Purchase Amount"
+//"Total Refund Amount"
+//"Base Currency"
+//"Select Date"
+//"Purchase Amount"
+//"Refund Amount"
+//"Applied Exchange Rate"
+//"Select Date"
+//"Close"
+//
+//
+//// 한국어
+//"총 구매 금액"
+//"총 환급 금액"
+//"기준화폐"
+//"날짜 선택"
+//"구매 금액"
+//"환급 금액"
+//"적용된 환율"
+//"날짜 선택"
+//"닫기"
+//
+//
+//// 일본어
+//"総購入金額"
+//"総還付金額"
+//"基準通貨"
+//"日付を選択"
+//"購入金額"
+//"還付金額"
+//"適用為替レート"
+//"日付を選択"
+//"閉じる"
+//
+//
+//// 스페인어
+//"Importe total de la compra"
+//"Importe total del reembolso"
+//"Moneda base"
+//"Seleccionar fecha"
+//"Importe de la compra"
+//"Importe del reembolso"
+//"Tipo de cambio aplicado"
+//"Seleccionar fecha"
+//"Cerrar"
+//
+//
+//// 프랑스어
+//"Montant total des achats"
+//"Montant total du remboursement"
+//"Devise de base"
+//"Sélectionner une date"
+//"Montant de l’achat"
+//"Montant du remboursement"
+//"Taux de change appliqué"
+//"Sélectionner une date"
+//"Fermer"
+//
+//
+//// 독일어
+//"Gesamtkaufbetrag"
+//"Gesamterstattungsbetrag"
+//"Basiswährung"
+//"Datum auswählen"
+//"Kaufbetrag"
+//"Erstattungsbetrag"
+//"Angewandter Wechselkurs"
+//"Datum auswählen"
+//"Schließen"
+//
+//
+//// 이탈리아어
+//"Importo totale degli acquisti"
+//"Importo totale del rimborso"
+//"Valuta base"
+//"Seleziona data"
+//"Importo dell’acquisto"
+//"Importo del rimborso"
+//"Tasso di cambio applicato"
+//"Seleziona data"
+//"Chiudi"
+//
+//
+//// 러시아어
+//"Общая сумма покупок"
+//"Общая сумма возврата"
+//"Базовая валюта"
+//"Выбрать дату"
+//"Сумма покупки"
+//"Сумма возврата"
+//"Применённый курс валют"
+//"Выбрать дату"
+//"Закрыть"
+//
+//
+//
+//// MARK: 실시간 환율 화면
+//// 영어
+//"Real-Time Exchange Rates"
+//"Last Updated"
+//
+//// 한국어
+//"실시간 환율정보"
+//"최근갱신일"
+//
+//// 일본어
+//"リアルタイム為替情報"
+//"最終更新日"
+//
+//// 스페인어
+//"Información de tipo de cambio en tiempo real"
+//"Última actualización"
+//
+//// 독일어
+//"Echtzeit-Wechselkursinformation"
+//"Letzte Aktualisierung"
+//
+//// 이탈리아어
+//"Informazioni sui tassi di cambio in tempo reale"
+//"Ultimo aggiornamento"
+//
+//// 프랑스어
+//"Informations sur les taux de change en temps réel"
+//"Dernière mise à jour"
+//
+//// 러시아어
+//"Информация о курсе валют в реальном времени"
+//"Последнее обновление"
+//
+//
+//// MARK: 설정화면
+//// 영어
+//"App Settings"
+//"Change Language"
+//"Change Base Currency"
+//"Change Travel Currency"
+//"Dark Mode"
+//"Reset Records"
+//"App Info"
+//"Version"
+//"Last Updated"
+//"Developer"
+//
+//// 한국어
+//"앱 설정"
+//"언어 변경"
+//"기준 화폐 변경"
+//"여행 화폐 변경"
+//"다크 모드"
+//"기록 초기화"
+//"앱 정보"
+//"버전"
+//"최종 업데이트"
+//"개발자"
+//
+//// 일본어
+//"アプリ設定"
+//"言語を変更"
+//"基準通貨を変更"
+//"旅行通貨を変更"
+//"ダークモード"
+//"記録をリセット"
+//"アプリ情報"
+//"バージョン"
+//"最終更新"
+//"開発者"
+//
+//// 스페인어
+//"Configuración de la app"
+//"Cambiar idioma"
+//"Cambiar moneda base"
+//"Cambiar moneda de viaje"
+//"Modo oscuro"
+//"Restablecer registros"
+//"Información de la app"
+//"Versión"
+//"Última actualización"
+//"Desarrollador"
+//
+//// 독일어
+//"App-Einstellungen"
+//"Sprache ändern"
+//"Basiswährung ändern"
+//"Reise-Währung ändern"
+//"Dunkelmodus"
+//"Aufzeichnungen zurücksetzen"
+//"App-Informationen"
+//"Version"
+//"Letztes Update"
+//"Entwickler"
+//
+//// 이탈리아어
+//"Impostazioni app"
+//"Cambia lingua"
+//"Cambia valuta base"
+//"Cambia valuta di viaggio"
+//"Modalità scura"
+//"Reimposta registrazioni"
+//"Info sull’app"
+//"Versione"
+//"Ultimo aggiornamento"
+//"Sviluppatore"
+//
+//// 프랑스어
+//"Paramètres de l’application"
+//"Changer la langue"
+//"Changer la devise de base"
+//"Changer la devise de voyage"
+//"Mode sombre"
+//"Réinitialiser les enregistrements"
+//"Infos sur l’app"
+//"Version"
+//"Dernière mise à jour"
+//"Développeur"
+//
+//// 러시아어
+//"Настройки приложения"
+//"Изменить язык"
+//"Изменить базовую валюту"
+//"Изменить валюту поездки"
+//"Тёмный режим"
+//"Сбросить записи"
+//"Информация о приложении"
+//"Версия"
+//"Последнее обновление"
+//"Разработчик"
+//
+//
+//// 영어
+//"Delete Records"
+//"Do you want to delete all records?"
+//"No"
+//"Yes"
+//
+//// 한국어
+//"기록 삭제"
+//"모든 기록을 삭제하시겠습니까?"
+//"아니오"
+//"예"
+//
+//// 일본어
+//"記録を削除"
+//"すべての記録を削除しますか？"
+//"いいえ"
+//"はい"
+//
+//// 스페인어
+//"Eliminar registros"
+//"¿Deseas eliminar todos los registros?"
+//"No"
+//"Sí"
+//
+//// 독일어
+//"Einträge löschen"
+//"Möchten Sie alle Einträge löschen?"
+//"Nein"
+//"Ja"
+//
+//// 이탈리아어
+//"Elimina registrazioni"
+//"Vuoi eliminare tutte le registrazioni?"
+//"No"
+//"Sì"
+//
+//// 프랑스어
+//"Supprimer les enregistrements"
+//"Voulez-vous supprimer tous les enregistrements ?"
+//"Non"
+//"Oui"
+//
+//// 러시아어
+//"Удалить записи"
+//"Вы хотите удалить все записи?"
+//"Нет"
+//"Да"

--- a/TaxRefundCalculator/en.lproj/Localizable.strings
+++ b/TaxRefundCalculator/en.lproj/Localizable.strings
@@ -786,3 +786,53 @@
 //"Вы хотите удалить все записи?"
 //"Нет"
 //"Да"
+
+
+// MARK:- 탭바
+//// 영어
+//"Calculate"
+//"History"
+//"Exchange Rate"
+//"Settings"
+//
+//// 한국어
+//"계산"
+//"기록"
+//"환율"
+//"설정"
+//
+//// 일본어
+//"計算"
+//"履歴"
+//"為替"
+//"設定"
+//
+//// 스페인어
+//"Calcular"
+//"Historial"
+//"Tipo de cambio"
+//"Configuración"
+//
+//// 독일어
+//"Berechnen"
+//"Verlauf"
+//"Wechselkurs"
+//"Einstellungen"
+//
+//// 이탈리아어
+//"Calcola"
+//"Storico"
+//"Tasso di cambio"
+//"Impostazioni"
+//
+//// 프랑스어
+//"Calculer"
+//"Historique"
+//"Taux de change"
+//"Paramètres"
+//
+//// 러시아어
+//"Расчет"
+//"История"
+//"Курс валют"
+//"Настройки"


### PR DESCRIPTION
## 주요내용
- UI통일 작업을 진행했습니다.
- 코너값을 `16`으로, 버튼들과 텍스트필드는 `12`일부 `Label`은 `20`으로 통일했습니다.
- 색상을 통일했습니다. 
배경색을 통일하고, 일부 맞지 않는 색들은 `Assets`에서 색상을 다시 설정했습니다.
텍스트는 `primaryText`로 통일했습니다. 일부 부제는 `subButton`컬러로 통일했습니다.
- 기록화면과, 실시간 환율화면에서 그림자를 추가했습니다.
계산화면, 설정화면과 같은 값으로 추가되었습니다.
- 탭바의 색상을 변경했습니다. 

---

## 스크린샷
<p align="center">
  <img src="https://github.com/user-attachments/assets/c89d26fc-77bc-4ac3-a2f7-1430edfdd7fd" width="32%" />
  <img src="https://github.com/user-attachments/assets/741ba105-4ebc-4757-9e8f-e73cd2367f5f" width="32%" />
  <img src="https://github.com/user-attachments/assets/51ced665-7d43-4b61-b0a8-752896ab40fd" width="32%" />
</p>
<p align="center">
  <img src="https://github.com/user-attachments/assets/f3ceb392-2390-4ad1-ac58-c19da1608e32" width="32%" />
  <img src="https://github.com/user-attachments/assets/30b0178a-4edf-4d66-92be-4a65ece93549" width="32%" />
  <img src="https://github.com/user-attachments/assets/1a3841da-ed64-4a80-91bd-2a453d8f9a48" width="32%" />
</p>

---

### 이슈번호 : #63 