### PR TITLE
Fix: 계산로직 국가별 숫자포맷 대응 기능 구현

### DIFF
--- a/TaxRefundCalculator/CalculatePage/CalculateVM.swift
+++ b/TaxRefundCalculator/CalculatePage/CalculateVM.swift
@@ -61,6 +61,19 @@ class CalculateVM {
         saveUserDefaults.getExchangeValue() ?? ""
     }
     
+    // MARK: Helper to parse localized number strings
+    func parseLocalizedNumber(_ string: String) -> Double? {
+        let locales = [Locale.current, Locale(identifier: "en_US"), Locale(identifier: "fr_FR"), Locale(identifier: "de_DE"), Locale(identifier: "it_IT"), Locale(identifier: "es_ES")]
+        for locale in locales {
+            let formatter = NumberFormatter()
+            formatter.locale = locale
+            formatter.numberStyle = .decimal
+            if let number = formatter.number(from: string) {
+                return number.doubleValue
+            }
+        }
+        return nil
+    }
     
     // MARK: 계산 기록 저장하기
     func saveCard(_ card: SavedCard) {
@@ -91,14 +104,12 @@ class CalculateVM {
         // 환율값 (String)
         let baseCurrencyValue = getExchangeValue()
         guard
-            let price = Double(priceText),
-            travelCurrencyUnit != 0
+            let price = parseLocalizedNumber(priceText),
+            travelCurrencyUnit != 0,
+            let baseRate = parseLocalizedNumber(baseCurrencyValue)
         else {
             return nil
         }
-        // 콤마 제거
-        let cleanedBaseCurrency = baseCurrencyValue.replacingOccurrences(of: ",", with: "")
-        guard let baseRate = Double(cleanedBaseCurrency) else { return nil }
         // 환산 공식: (구매금액 / 단위) * 환율
         return price / Double(travelCurrencyUnit) * baseRate
     }
@@ -106,7 +117,7 @@ class CalculateVM {
     // 환급금액 계산
     func calculateVatRefund(priceText: String) -> Double? {
         guard
-            let price = Double(priceText),
+            let price = parseLocalizedNumber(priceText),
             let vatString = getVatRate()?.replacingOccurrences(of: "%", with: ""),
             let vat = Double(vatString)
         else { return nil }
@@ -117,8 +128,7 @@ class CalculateVM {
     func convertRefundToBaseCurrency(refund: Double) -> Double? {
         let travelCurrencyUnit = getTravelCurrencyUnit()
         let baseCurrencyValue = getExchangeValue()
-        let cleanedBaseCurrency = baseCurrencyValue.replacingOccurrences(of: ",", with: "")
-        guard let baseRate = Double(cleanedBaseCurrency) else { return nil }
+        guard let baseRate = parseLocalizedNumber(baseCurrencyValue) else { return nil }
         // 환산 공식: (환급금액 / 단위) * 환율
         return refund / Double(travelCurrencyUnit) * baseRate
     }


### PR DESCRIPTION
## 🔵 변경사항
- 다양한 국가의 숫자 포맷(천 단위/소수점 구분자 차이)에 대응하여,
유럽식(예: 1.234,56) 및 영미식(1,234.56) 표기 모두 정상적으로 계산이 가능하도록 변경
---

## 🟢 주요 내용
- 기존에는 콤마(,)를 제거한 뒤 Double로 변환하는 방식이라 미국식(1,234.56)은 정상 처리되나
유럽식(1.234,56) 표기에는 대응하지 못해 계산이 되지 않거나 잘못된 값이 나왔음
- NumberFormatter와 여러 Locale(영미/유럽 주요국가)을 순차적으로 적용하여
다양한 숫자 포맷을 안전하게 Double로 변환하도록 개선
- 이제 환율 데이터가 어떤 국가 포맷이든 정확하게 계산 가능

---

## 스크린샷 ( Before )
<img width="300" alt="" src="https://github.com/user-attachments/assets/b3ac04ce-f124-4bf7-a3f5-96c9cfc1a9af" />

- 계산로직이 꼬임

## 스크린샷 ( After )
<img width="300" alt="" src="https://github.com/user-attachments/assets/9e915091-e20b-4846-a5f2-18ccd266a8cb" />

Resolves: #70 
