### PR TITLE
Fix: 다양한 숫자포맷 지원에 따른 버그 수정

### DIFF
--- a/TaxRefundCalculator/CalculatePage/CalculateVC.swift
+++ b/TaxRefundCalculator/CalculatePage/CalculateVC.swift
@@ -407,10 +407,10 @@ class CalculateVC: UIViewController {
               let refundText = refundNum.text,
               let convertedPriceText = conversionBoughtPrice.text,
               let convertedText = conversionRefuncPrice.text,
-              let price = Double(priceText),
-              let refund = Double(refundText.filter { $0.isNumber || $0 == "." }),
-              let convertedPrice = Double(convertedPriceText.filter { $0.isNumber || $0 == "." }),
-              let convertedRefundPrice = Double(convertedText.filter { $0.isNumber || $0 == "." }) else {
+              let price = viewModel.parseLocalizedNumber(priceText),
+              let refund = viewModel.parseLocalizedNumber(refundText),
+              let convertedPrice = viewModel.parseLocalizedNumber(extractNumberString(convertedPriceText)),
+              let convertedRefundPrice = viewModel.parseLocalizedNumber(extractNumberString(convertedText)) else {
             print("❌ 필수 데이터 누락 또는 변환 실패")
             return
         }
@@ -432,6 +432,11 @@ class CalculateVC: UIViewController {
         print("✅ 저장 성공: \(card)")
         compliteAlert()
     }
+    
+    func extractNumberString(_ string: String) -> String {
+        return string.components(separatedBy: CharacterSet(charactersIn: "0123456789.,").inverted).joined()
+    }
+    
     // 저장 완료 Alert
     private func compliteAlert() {
         let alert = UIAlertController(title: NSLocalizedString("Save Complete", comment: ""), message: NSLocalizedString("Saved successfully.", comment: ""), preferredStyle: .alert)

--- a/TaxRefundCalculator/CalculatePage/CalculateVC.swift
+++ b/TaxRefundCalculator/CalculatePage/CalculateVC.swift
@@ -433,6 +433,9 @@ class CalculateVC: UIViewController {
         compliteAlert()
     }
     
+    /// 문자열에서 숫자, 소수점, 콤마만 추출하는 유틸리티 함수
+    /// - "약 1,234.56 USD" → "1,234.56"
+    /// - "Approx. 12.000,00 EUR" → "12.000,00"
     func extractNumberString(_ string: String) -> String {
         return string.components(separatedBy: CharacterSet(charactersIn: "0123456789.,").inverted).joined()
     }

--- a/TaxRefundCalculator/CalculatePage/CalculateVM.swift
+++ b/TaxRefundCalculator/CalculatePage/CalculateVM.swift
@@ -59,16 +59,31 @@ class CalculateVM {
     }
     
     // MARK: - 숫자 출력 방식 보정
+    /// String -> Double, 다양한 국가별 숫자 포맷을 자동 인식하여 파싱하는 함수
+    /// - 사용자가 직접 입력하거나, 외부 API·서버 등에서 받아온 숫자 값이
+    ///   각 국가별 포맷(천 단위·소수점 구분자)이 다를 수 있기 때문에
+    /// - 우선적으로 사용자의 아이폰 로케일(`Locale.current`)을 사용해 파싱 시도
+    /// - 실패 시 대표적인 포맷을 순차적으로 파싱 시도
     func parseLocalizedNumber(_ string: String) -> Double? {
-        let locales = [Locale.current, Locale(identifier: "en_US"), Locale(identifier: "fr_FR"), Locale(identifier: "de_DE"), Locale(identifier: "it_IT"), Locale(identifier: "es_ES")]
+        // 1. 사용자의 기기 설정을 우선 적용하고, 실패시 대표 로케일로 파싱
+        let locales = [
+            Locale.current,
+            Locale(identifier: "en_US"),
+            Locale(identifier: "fr_FR"),
+            Locale(identifier: "de_DE"),
+            Locale(identifier: "it_IT"),
+            Locale(identifier: "es_ES")
+        ]
         for locale in locales {
             let formatter = NumberFormatter()
             formatter.locale = locale
             formatter.numberStyle = .decimal
+            // 각 국가별 표기법(천 단위, 소수점 구분자)에 맞게 파싱
             if let number = formatter.number(from: string) {
                 return number.doubleValue
             }
         }
+        // 모든 로케일에 실패하면 nil 반환
         return nil
     }
     

--- a/TaxRefundCalculator/SavedPage/SavedCardCell.swift
+++ b/TaxRefundCalculator/SavedPage/SavedCardCell.swift
@@ -50,7 +50,7 @@ final class SavedCardCell: UITableViewCell {
         $0.contentHorizontalAlignment = .fill
         $0.contentVerticalAlignment = .fill
     }
-
+    
     private let purchaseTitleLabel = UILabel().then {
         $0.font = .systemFont(ofSize: 14, weight: .medium)
         $0.text = NSLocalizedString("Purchase Amount", comment: "")
@@ -219,20 +219,22 @@ final class SavedCardCell: UITableViewCell {
         let currencyCode = parts.last ?? ""    // "THB"
         countryLabel.text = countryName
         dateLabel.text = model.date
-        purchaseAmountLabel.text = "\(model.price.roundedString()) \(currencyCode)"
-        convertedPurchaseLabel.text = "\(model.convertedPrice.roundedString()) \(model.baseCurrencyCode)"
-        refundAmountLabel.text = "\(model.refundPrice.roundedString()) \(model.country.suffix(3))"
-        convertedRefundLabel.text = "\(model.convertedRefundPrice.roundedString()) \(model.baseCurrencyCode)"
+        
+        purchaseAmountLabel.text = "\(model.price.roundedString()) \(model.currencyCode)"
+            convertedPurchaseLabel.text = "\(model.convertedPrice.roundedString()) \(model.baseCurrencyCode)"
+            refundAmountLabel.text = "\(model.refundPrice.roundedString()) \(model.currencyCode)"
+            convertedRefundLabel.text = "\(model.convertedRefundPrice.roundedString()) \(model.baseCurrencyCode)"
+        
         // 삭제 핸들러
         self.deleteHandler = onDelete
         bindDeleteButton()
     }
     
     private func bindDeleteButton() {
-            deleteButton.rx.tap
-                .subscribe(onNext: { [weak self] in
-                    self?.deleteHandler?()
-                })
-                .disposed(by: disposeBag)
-        }
+        deleteButton.rx.tap
+            .subscribe(onNext: { [weak self] in
+                self?.deleteHandler?()
+            })
+            .disposed(by: disposeBag)
+    }
 }

--- a/TaxRefundCalculator/Utils/Double+Formatted.swift
+++ b/TaxRefundCalculator/Utils/Double+Formatted.swift
@@ -7,22 +7,27 @@
 
 import Foundation
 
-/// 숫자 표시 포맷 유틸
+/// Double 타입 숫자를 로케일(국가별 설정)에 맞게 문자열로 변환해주는 유틸리티
 extension Double {
+    /// 소수점 이하 자리수를 지정하여, 사용자의 Locale(국가 설정)에 맞는 숫자 문자열로 변환
+    /// - Parameter fractionDigits: 표시할 소수점 이하 자리수(기본값: 2)
+    /// - Returns: 천 단위 구분자, 소수점 처리 등이 반영된 문자열 (예: 1,234.56, 1.234,56 등)
     func roundedString(fractionDigits: Int = 2) -> String {
-            let formatter = NumberFormatter()
-            formatter.numberStyle = .decimal
-            formatter.locale = Locale.current
-            formatter.minimumFractionDigits = 0
-            formatter.maximumFractionDigits = fractionDigits
-            let number = NSNumber(value: self)
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal // 천 단위 구분자, 소수점 등 국가별 스타일 적용
+        formatter.locale = Locale.current // 현재 사용자의 아이폰 설정 로케일을 자동 적용
+        formatter.minimumFractionDigits = 0 // 0이면 소수점 이하가 모두 0일 때는 표시하지 않음
+        formatter.maximumFractionDigits = fractionDigits
+        let number = NSNumber(value: self)
         var string = formatter.string(from: number) ?? "\(self)"
         
-        // 소수점이 0만 남으면 제거
+        // 아래는 “뒷자리에 소수점이 0만 남았을 때 표시하지 않도록” 추가 가공
         if let decimalSeparator = formatter.decimalSeparator, string.contains(decimalSeparator) {
+            // 소수점 이하가 0이면 0을 하나씩 제거 (예: 1,230.00 → 1,230)
             while string.last == "0" {
                 string.removeLast()
             }
+            // 소수점만 남았으면 소수점 기호 자체도 제거 (예: 1,230. → 1,230)
             if string.last == Character(decimalSeparator) {
                 string.removeLast()
             }

--- a/TaxRefundCalculator/Utils/Double+Formatted.swift
+++ b/TaxRefundCalculator/Utils/Double+Formatted.swift
@@ -10,10 +10,23 @@ import Foundation
 /// 숫자 표시 포맷 유틸
 extension Double {
     func roundedString(fractionDigits: Int = 2) -> String {
-        let formatter = NumberFormatter()
-        formatter.minimumFractionDigits = fractionDigits
-        formatter.maximumFractionDigits = fractionDigits
-        formatter.numberStyle = .decimal
-        return formatter.string(from: NSNumber(value: self)) ?? "\(self)"
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+            formatter.locale = Locale.current
+            formatter.minimumFractionDigits = 0
+            formatter.maximumFractionDigits = fractionDigits
+            let number = NSNumber(value: self)
+        var string = formatter.string(from: number) ?? "\(self)"
+        
+        // 소수점이 0만 남으면 제거
+        if let decimalSeparator = formatter.decimalSeparator, string.contains(decimalSeparator) {
+            while string.last == "0" {
+                string.removeLast()
+            }
+            if string.last == Character(decimalSeparator) {
+                string.removeLast()
+            }
+        }
+        return string
     }
 }


### PR DESCRIPTION
## 🔵 변경사항
- 숫자포맷 유틸 수정 ( `formatter.locale` = `Locale.current` 적용 )
- 계산로직 내에서 `parseLocalizedNumber' , `extractNumberString` 적용
 
## 🟢 주요 내용
- 다양한 국가 숫자 표시 형식에 대응하기 위해 수정 후 발생된 버그 수정
- 자연스러운 계산 되도록 소수점 뒤 0 일 경우 제거

## 수정 전 

<img width="300" alt="" src="https://github.com/user-attachments/assets/fcf258f2-47c2-4a1a-9006-3f8ebcad644c" />

<img width="300" alt="" src="https://github.com/user-attachments/assets/de615774-ab1e-423e-907d-98ddb749cf1f" />

## 수정 후

<img width="300" alt="" src="https://github.com/user-attachments/assets/177991ed-1c78-4400-af78-90cc21528b9c" />

<img width="300" alt="" src="https://github.com/user-attachments/assets/67e094cf-cfa4-4729-8bf4-005b5c989519" />

Resolves : #87 