### PR TITLE
Feat: 설정탭에서 통화 중복선택 방지 예외처리 구현

### DIFF
--- a/TaxRefundCalculator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TaxRefundCalculator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f19b3acf316ce2f4fb85dcca1e9c865120e75b9e92bea165441e71f911642aab",
+  "originHash" : "37434367a40c44e577570c92fd3ce2d174c0d44efb775ff19d53e64757a7bd7c",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",

--- a/TaxRefundCalculator/Modals/CountryModal.swift
+++ b/TaxRefundCalculator/Modals/CountryModal.swift
@@ -18,6 +18,8 @@ class CountryModal: UIViewController {
     weak var delegate: CountryModalDelegate?
     var selectedTextFieldTag: Int?
     
+    var currentBaseCurrency: String?
+    var currentTravelCurrency: String?
     
     // MARK: - 지원국가 목록 배열
     private let countries = [
@@ -130,7 +132,31 @@ extension CountryModal: UITableViewDelegate {
         print("\(countries[indexPath.row])") // 선택된 국가
         
         if let tag = selectedTextFieldTag {
-            // tag == 1 (여행국가)에서만 USD/GBP 제한 적용
+            // MARK: 중복 선택 체크
+            if tag == 0 && selectedCountry == currentTravelCurrency {
+                let alert = UIAlertController(
+                    title: "\(NSLocalizedString("Notice", comment: ""))",
+                    message: "\(NSLocalizedString("CurrencyCountryDuplicateError", comment: ""))",
+                    preferredStyle: .alert
+                )
+                alert.addAction(UIAlertAction(title: "\(NSLocalizedString("OK", comment: ""))", style: .default, handler: nil))
+                present(alert, animated: true, completion: nil)
+                tableView.deselectRow(at: indexPath, animated: true)
+                return
+            }
+            if tag == 1 && selectedCountry == currentBaseCurrency {
+                let alert = UIAlertController(
+                    title: "\(NSLocalizedString("Notice", comment: ""))",
+                    message: "\(NSLocalizedString("CurrencyCountryDuplicateError", comment: ""))",
+                    preferredStyle: .alert
+                )
+                alert.addAction(UIAlertAction(title: "\(NSLocalizedString("OK", comment: ""))", style: .default, handler: nil))
+                present(alert, animated: true, completion: nil)
+                tableView.deselectRow(at: indexPath, animated: true)
+                return
+            }
+            
+            // MARK: tag == 1 (여행국가)에서만 USD/GBP 제한 적용
             if tag == 1 && (selectedCountry.contains("USD") || selectedCountry.contains("GBP")) {
                 let alert = UIAlertController(
                     title: "\(NSLocalizedString("Notice", comment: ""))",

--- a/TaxRefundCalculator/SettingPage/SettingVC.swift
+++ b/TaxRefundCalculator/SettingPage/SettingVC.swift
@@ -49,7 +49,7 @@ class SettingVC: UIViewController, CountryModalDelegate {
         $0.textColor = .primaryText
         $0.font = .systemFont(ofSize: 17)
     }
-    private let nowCurreny = UILabel().then {
+    private let nowCurrency = UILabel().then {
         $0.textColor = .primaryText
         $0.font = .systemFont(ofSize: 17)
     }
@@ -136,7 +136,7 @@ class SettingVC: UIViewController, CountryModalDelegate {
         }
         // 여행화폐 설정
         if let loadTravelCountry = viewModel.getTravelCountry() {
-            nowCurreny.text = loadTravelCountry
+            nowCurrency.text = loadTravelCountry
         }
         // 다크모드 스위치 활성화 체크
         darkModeSwitch.isOn = viewModel.getDarkModeEnabled()
@@ -163,7 +163,7 @@ class SettingVC: UIViewController, CountryModalDelegate {
         
         settingCard.addSubview(currencyRow)
         currencyRow.addSubview(currencyChange)
-        currencyRow.addSubview(nowCurreny)
+        currencyRow.addSubview(nowCurrency)
         
         settingCard.addSubview(darkModeRow)
         darkModeRow.addSubview(darkMode)
@@ -203,7 +203,7 @@ class SettingVC: UIViewController, CountryModalDelegate {
             $0.leading.equalToSuperview().inset(16)
             $0.centerY.equalToSuperview()
         }
-        nowCurreny.snp.makeConstraints {
+        nowCurrency.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(16)
             $0.centerY.equalToSuperview()
         }
@@ -292,20 +292,23 @@ class SettingVC: UIViewController, CountryModalDelegate {
     // MARK: - Tap Actions 클릭시 모달로 출력
     @objc
     private func didTapBaseCurrencyRow() {
-        let vc = CountryModal()
-        vc.delegate = self
-        vc.selectedTextFieldTag = baseCurrencyRow.tag
-        vc.modalPresentationStyle = .pageSheet
-        present(vc, animated: true, completion: nil)
+        let modal = CountryModal()
+        modal.delegate = self
+        modal.selectedTextFieldTag = baseCurrencyRow.tag
+        modal.currentBaseCurrency = nowBaseCurrency.text
+        modal.currentTravelCurrency = nowCurrency.text
+        modal.modalPresentationStyle = .pageSheet
+        present(modal, animated: true, completion: nil)
     }
-
     @objc
     private func didTapTravelCountryRow() {
-        let vc = CountryModal()
-        vc.delegate = self
-        vc.selectedTextFieldTag = currencyRow.tag
-        vc.modalPresentationStyle = .pageSheet
-        present(vc, animated: true, completion: nil)
+        let modal = CountryModal()
+        modal.delegate = self
+        modal.selectedTextFieldTag = currencyRow.tag
+        modal.currentBaseCurrency = nowBaseCurrency.text
+        modal.currentTravelCurrency = nowCurrency.text
+        modal.modalPresentationStyle = .pageSheet
+        present(modal, animated: true, completion: nil)
     }
     @objc
     private func didTapResetRow() {
@@ -331,9 +334,9 @@ class SettingVC: UIViewController, CountryModalDelegate {
         switch tag {
         case 0:
             nowBaseCurrency.text = country
-            SettingVM.shared.saveBaseCurrency(country) // userDefaults에 저장 및 Combine
+            SettingVM.shared.saveBaseCurrency(country)
         case 1:
-            nowCurreny.text = country
+            nowCurrency.text = country
             SettingVM.shared.saveTravelCountry(country) // userDefaults에 저장 및 Combine
         default:
             break

--- a/TaxRefundCalculator/SettingPage/SettingVM.swift
+++ b/TaxRefundCalculator/SettingPage/SettingVM.swift
@@ -22,6 +22,7 @@ class SettingVM {
         setupCombineBindings()
     }
     
+    
     // MARK: - Combine 환율 정보, 환폐단위 최신화
     @Published var exchangeValue: String = ""
     @Published var travelCurrencyUnit: Int = 1
@@ -36,6 +37,7 @@ class SettingVM {
     private var cancellables = Set<AnyCancellable>()
     
     let saveUserDefaults = SaveUserDefaults()
+    
     
     // MARK: - userDefaults 저장 메서드
     func saveBaseCurrency(_ baseCurrency: String) {
@@ -55,6 +57,7 @@ class SettingVM {
         self.exchangeValue = exchangeValue
     }
     
+    
     // MARK: - userDefaults 조회 메서드
     func getBaseCurrency() -> String? {
         return saveUserDefaults.getBaseCurrency()
@@ -73,11 +76,14 @@ class SettingVM {
         saveUserDefaults.getDarkModeEnabled()
     }
     
+    
     // MARK: - 기록 초기화
     func deleteAllRecords() {
         saveUserDefaults.deleteAllRecords()
     }
     
+    
+    // MARK: - 컴바인
     private func setupCombineBindings() {
         // 기준 화폐가 변경되었을 때
         $baseCurrency
@@ -86,7 +92,7 @@ class SettingVM {
                 self?.updateExchangeInfoAfterCurrencyChange()
             }
             .store(in: &cancellables)
-        // 여행 화폐도 동일하게 바인딩 (필요 시)
+        // 여행 화폐도 동일하게 바인딩
         $travelCountry
             .dropFirst()
             .sink { [weak self] _ in


### PR DESCRIPTION
## 주요 내용
- 설정 탭에서 기준통화, 여행국가 통화를 선택할 때, 중복선택이 되지 않도록 예외처리 하였습니다.
- 텍스트 로컬라이징은 시작화면에서 사용한 모달의 텍스트들을 그대로 재사용하였습니다.

---

## 스크린샷
<img width="568" alt="스크린샷 2025-07-02 오전 1 21 13" src="https://github.com/user-attachments/assets/01899bf5-65cf-472e-9d7e-014445e13a0d" />

---

Resolved: #102 