### PR TITLE
Update: 🚀 v1.0.5 업데이트

### DIFF
--- a/TaxRefundCalculator.xcodeproj/project.pbxproj
+++ b/TaxRefundCalculator.xcodeproj/project.pbxproj
@@ -182,11 +182,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 76CW3C5UU7;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TaxRefundCalculator/SupportingFiles/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
@@ -196,9 +198,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.4;
+				MARKETING_VERSION = 1.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.JaegunLee.TaxRefundCalculator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -215,11 +218,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 76CW3C5UU7;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TaxRefundCalculator/SupportingFiles/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
@@ -229,9 +234,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.4;
+				MARKETING_VERSION = 1.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.JaegunLee.TaxRefundCalculator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/TaxRefundCalculator/Models/SaveUserDefaults.swift
+++ b/TaxRefundCalculator/Models/SaveUserDefaults.swift
@@ -76,7 +76,7 @@ class SaveUserDefaults: SaveUserDefaultsProtocol {
     }
 }
 
-// MARK: - 설정탭 기록카드 관련
+// MARK: - 기록저장
 extension SaveUserDefaults {
     // 모든 SavedCard 배열을 1개 Key("SavedCardList")로 통째로 저장
     func overwriteAllCards(_ cards: [SavedCard]) {

--- a/TaxRefundCalculator/Utils/Double+Formatted.swift
+++ b/TaxRefundCalculator/Utils/Double+Formatted.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// Double 타입 숫자를 로케일(국가별 설정)에 맞게 문자열로 변환해주는 유틸리티
+// MARK: -  Double 타입 숫자를 로케일(국가별 설정)에 맞게 문자열로 변환해주는 유틸리티
 extension Double {
     /// 소수점 이하 자리수를 지정하여, 사용자의 Locale(국가 설정)에 맞는 숫자 문자열로 변환
     /// - Parameter fractionDigits: 표시할 소수점 이하 자리수(기본값: 2)


### PR DESCRIPTION
## 주요내용
-  앱 실행 시 환율 데이터 동기화가 완료되기 전에 바로 TabBarController로 진입하여, 
   일부 기기에서 API 갱신이 누락되는 문제 해결
- 또한, Firebase에 저장되는 환율 데이터의 날짜 기준이 대한민국 시간대(Asia/Seoul) 로 설정되어 있어, 다른 국가에서 접속 시 혼란 가능성 존재
  ->  UTC로 변경하여 해결

**관련 PR**
[Fix: 데이터 싱크 후 화면 전환 처리 & TimeZone UTC 기준 통일 #138 ](https://github.com/TaxRefundCalculator/TaxRefundCalculator/pull/138)

Resolved: #139  