### PR TITLE
Fix: 환율 API가 호출되지 않던 문제 해결 및 버전 정보 업데이트

### DIFF
--- a/TaxRefundCalculator.xcodeproj/project.pbxproj
+++ b/TaxRefundCalculator.xcodeproj/project.pbxproj
@@ -184,7 +184,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 76CW3C5UU7;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TaxRefundCalculator/SupportingFiles/Info.plist;
@@ -198,7 +198,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.JaegunLee.TaxRefundCalculator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -220,7 +220,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 76CW3C5UU7;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TaxRefundCalculator/SupportingFiles/Info.plist;
@@ -234,7 +234,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.JaegunLee.TaxRefundCalculator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/TaxRefundCalculator/SettingPage/SettingVC.swift
+++ b/TaxRefundCalculator/SettingPage/SettingVC.swift
@@ -103,7 +103,7 @@ class SettingVC: UIViewController, CountryModalDelegate {
         $0.textColor = .subText
     }
     private let versionNumber = UILabel().then {
-        $0.text = "1.0.5"
+        $0.text = "1.0.6"
         $0.font = UIFont.systemFont(ofSize: 17, weight: .thin)
         $0.textColor = .subText
     }
@@ -113,7 +113,7 @@ class SettingVC: UIViewController, CountryModalDelegate {
         $0.textColor = .subText
     }
     private let updateDay = UILabel().then {
-        $0.text = "2025.07.31"
+        $0.text = "2025.08.29"
         $0.font = UIFont.systemFont(ofSize: 17, weight: .thin)
         $0.textColor = .subText
     }


### PR DESCRIPTION
## 주요내용 
- 환율 API가 호출되지 않는 문제를 해결하였습니다. (API 키 누락)
- 깃허브상에는 키값을 노출시킬 수 없기 때문에 이그노어에 추가되어서 보이지 않습니다.
- 버전 정보를 업데이트하였습니다.